### PR TITLE
bsc#1198127 - port fix from scaleUp

### DIFF
--- a/SAPHana/SAPHanaSR-ScaleOut.changes_12
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_12
@@ -1,4 +1,23 @@
 -------------------------------------------------------------------
+Fri Aug  5 10:05:30 UTC 2022 - abriel@suse.com
+
+- Version bump to 0.183.1 - Testversion
+- add new HA/DR provider hook susChkSrv
+  (jsc#PED-xxxx)
+- changes to the demote_clone function of the resource agent:
+  if the role is '*:shtdown:shtdown:shtdown' (topology agent run
+  into timeouts) the function fail with rc=1, to get the managed
+  resource stopped
+  changes to the stop_clone function of the topology agent:
+  call landscapeHostConfiguration.py and set the roles as they were
+  reported. If the command timed out, set the role to
+  '*:shtdown:shtdown:shtdown' and return 1 to get the node fenced.
+  The used timeout for the landscapeHostConfiguration.py call can
+  be configured by the cluster action timeout, if needed. It will
+  be 50% of the action timeout or the minimum of 300s.
+  (bsc#1198127)
+
+-------------------------------------------------------------------
 Mon Jan 10 09:57:21 UTC 2022 - abriel@suse.com
 
 - change version to 0.181.0

--- a/SAPHana/SAPHanaSR-ScaleOut.changes_15
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_15
@@ -1,4 +1,23 @@
 -------------------------------------------------------------------
+Fri Aug  5 10:05:30 UTC 2022 - abriel@suse.com
+
+- Version bump to 0.183.1 - Testversion
+- add new HA/DR provider hook susChkSrv
+  (jsc#PED-xxxx)
+- changes to the demote_clone function of the resource agent:
+  if the role is '*:shtdown:shtdown:shtdown' (topology agent run
+  into timeouts) the function fail with rc=1, to get the managed
+  resource stopped
+  changes to the stop_clone function of the topology agent:
+  call landscapeHostConfiguration.py and set the roles as they were
+  reported. If the command timed out, set the role to
+  '*:shtdown:shtdown:shtdown' and return 1 to get the node fenced.
+  The used timeout for the landscapeHostConfiguration.py call can
+  be configured by the cluster action timeout, if needed. It will
+  be 50% of the action timeout or the minimum of 300s.
+  (bsc#1198127)
+
+-------------------------------------------------------------------
 Mon Jan 10 09:57:21 UTC 2022 - abriel@suse.com
 
 - change version to 0.181.0

--- a/SAPHana/SAPHanaSR-ScaleOut.spec
+++ b/SAPHana/SAPHanaSR-ScaleOut.spec
@@ -21,7 +21,7 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Resource agents to control the HANA database in system replication setup
-Version:        0.181.0
+Version:        0.183.1
 Release:        0
 Url:            http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution
 Source0:        SAPHanaSR-ScaleOut-%{version}.tar.bz2
@@ -108,6 +108,7 @@ install -Dm 0444 wizard/workflows/90-SAPHanaSR-ScaleOut.xml  %{buildroot}/srv/ww
 # HANA hooks
 install -m 0644 srHook/SAPHanaSR.py %{buildroot}/usr/share/%{name}/
 install -m 0644 srHook/SAPHanaSrMultiTarget.py %{buildroot}/usr/share/%{name}/
+install -m 0644 srHook/susChkSrv.py %{buildroot}/usr/share/%{name}/
 install -m 0444 srHook/global.ini %{buildroot}/usr/share/%{name}/samples
 install -m 0444 srHook/sudoers %{buildroot}/usr/share/%{name}/samples
 

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -34,7 +34,7 @@
 #     systemReplicationStatus.py (>= SPS090)
 #
 #######################################################################
-SAPHanaControllerVersion="0.181.0.1226.1907"
+SAPHanaControllerVersion="0.183.1"
 # Resource Agent Generation
 RAG="2.0"
 
@@ -3290,6 +3290,13 @@ function saphana_demote_clone() {
     local rc=$OCF_ERR_GENERIC;
     set_hana_attribute ${NODENAME} "DEMOTED" "${ATTR_NAME_HANA_CLONE_STATE[@]}"
     rc=$OCF_SUCCESS;
+    # bsc#1198127: let it fail, to get the resource stopped.
+    my_role=$(get_hana_attribute "${NODENAME}" "${ATTR_NAME_HANA_ROLES[@]}")
+    if [[ "$my_role" =~ "*:shtdown:shtdown:shtdown*" ]]; then
+        rc=$OCF_ERR_GENERIC
+    else
+        rc=$OCF_SUCCESS
+    fi
     super_ocf_log info "ACT: Demoted $SID-$InstanceName."
     super_ocf_log info "FLOW $FUNCNAME rc=$rc"
     return $rc

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -26,7 +26,7 @@
 #
 #######################################################################
 # DONE PRIO 1: AFTER(!) SAP HANA SPS12 is available we could use hdbnsutil --sr_stateConfiguration
-SAPHanaTopologyVersion="0.181.0.1228.1907"
+SAPHanaTopologyVersion="0.183.1"
 #
 # Initialization:
 timeB=$(date '+%s')
@@ -883,8 +883,9 @@ function sht_start_clone() {
 function sht_stop_clone() {
     super_ocf_log info "FLOW $FUNCNAME ($*)"
     local rc=0
+    local tout=0
     local nRole nLsc nSrmode nNsConf nNsCurr nIsConf nIsCurr
-	check_for_primary; primary_status=$?
+    check_for_primary; primary_status=$?
     if [ $primary_status -eq $HANA_STATE_PRIMARY ]; then
         hanaPrim="P"
     elif [ $primary_status -eq $HANA_STATE_SECONDARY ]; then
@@ -894,10 +895,61 @@ function sht_stop_clone() {
     else
         hanaPrim="-"
     fi
-    nRole=$(get_hana_attribute ${node} "${ATTR_NAME_HANA_ROLES[@]}" | tr ':' ' ')
-    read nNsConf nNsCurr nIsConf nIsCurr <<< $nRole
-    set_hana_attribute "${NODENAME}" "$nNsConf:shtdown:shtdown:shtdown" "${ATTR_NAME_HANA_ROLES[@]}"
-    sht_stop; rc=$?
+    # bsc#1198127
+    # we do not use our usual HANA_CALL_TIMEOUT for this call of
+    # 'landscapeHostConfiguration.py', but a much longer one, because if the
+    # timeout is reached, the node will be fenced. So it is a critical call
+    # and should get reasonable time to succeed.
+    # But it will be configurable by the cluster config (action timeout), if a
+    # system needs more time than we expected. The minimum used timeout is 300s
+    #
+    # timeOut = max(300, 50%(actionTimeOut))
+    # $OCF_RESKEY_CRM_meta_timeout is the timeout of the current running action
+    # in ms
+    local actionTimeOut="$OCF_RESKEY_CRM_meta_timeout"
+    local stdTimeOut=300
+    local actTimeOutPercent=50
+    if [ -z "$actionTimeOut" ]; then
+        actionTimeOut="$stdTimeOut"
+    else
+        # actionTimeOut in seconds
+        ((actionTimeOut = actionTimeOut/1000))
+    fi
+    # 50%(actionTimeOut)
+    ((timeout = actionTimeOut * actTimeOutPercent/100))
+    # max(300, 50%(actionTimeOut))
+    if [ -z "$timeout" ] || [ "$timeout" -lt "$stdTimeOut" ]; then
+        timeout=$stdTimeOut
+    fi
+
+    hanaANSWER=$(HANA_CALL --timeout "$timeout" --cmd "landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
+    if [ "$hanalrc" -ge 124 ]; then
+        # timeout of HANA_CALL, set role to '$nNsConf:shtdown:shtdown:shtdown'
+        # to get the saphana_demote_clone to fail and stop the resource
+        nRole=$(get_hana_attribute ${node} "${ATTR_NAME_HANA_ROLES[@]}" | tr ':' ' ')
+        read nNsConf nNsCurr nIsConf nIsCurr <<< $nRole
+        set_hana_attribute "${NODENAME}" "$nNsConf:shtdown:shtdown:shtdown" "${ATTR_NAME_HANA_ROLES[@]}"
+        # and exit with 1 to let the stop fail
+        tout=1
+    else
+        hanarole=$(echo "$hanaANSWER" | tr -d ' ' | \
+            awk -F= '
+            $1 == "host/"vName"/nameServerConfigRole"  {nsCR=$2}
+            $1 == "host/"vName"/nameServerActualRole"  {nsAR=$2}
+            $1 == "host/"vName"/indexServerConfigRole" {isCR=$2}
+            $1 == "host/"vName"/indexServerActualRole" {isAR=$2}
+            $1 == "nameServerConfigRole"  {nsCR=$2}
+            $1 == "nameServerActualRole"  {nsAR=$2}
+            $1 == "indexServerConfigRole" {isCR=$2}
+            $1 == "indexServerActualRole" {isAR=$2}
+            END { printf "%s:%s:%s:%s\n", nsCR, nsAR, isCR, isAR;  } ' vName=$vName )
+        set_hana_attribute ${NODENAME} "$hanarole" "${ATTR_NAME_HANA_ROLES[@]}"
+    fi
+    sht_stop; rc=$? # till now it returns everytime $OCF_SUCCESS
+    if [ "$tout" -eq 1 ]; then
+        # timeout of landscapeHostConfiguration.py - let stop fail
+        rc=$OCF_ERR_GENERIC
+    fi
     return $rc
 }
 
@@ -969,10 +1021,17 @@ function sht_monitor_clone() {
     if [ -z "$vName" ]; then
        vName=${NODENAME}
     fi
+    setRole=true
     hanaANSWER=$(HANA_CALL --timeout $HANA_CALL_TIMEOUT --cmd "landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
+    # landscape timeout - retry command
     if [ "$hanalrc" -eq 124 ]; then
-        # landscape timeout
-        super_ocf_log warn "RA: landscapeHostConfiguration.py TIMEOUT after $HANA_CALL_TIMEOUT seconds"
+        super_ocf_log warn "RA: HANA_CALL timed out after $HANA_CALL_TIMEOUT seconds running command 'landscapeHostConfiguration.py --sapcontrol=1'. Retrying..."
+        hanaANSWER=$(HANA_CALL --timeout "$HANA_CALL_TIMEOUT" --cmd "landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"
+        # if the second try again run into a timeout, log an error and do not set hanarole but keep the previous settings.
+        if [ "$hanalrc" -ge 124 ]; then
+            super_ocf_log err "RA: HANA_CALL Operation timeout after $HANA_CALL_TIMEOUT seconds running command 'landscapeHostConfiguration.py --sapcontrol=1'."
+                setRole=false
+        fi
     fi
     #
     # scan with and without host prefix to allow also single instances (scaleup) for smaller test environments
@@ -988,7 +1047,9 @@ function sht_monitor_clone() {
             $1 == "indexServerConfigRole" {isCR=$2}
             $1 == "indexServerActualRole" {isAR=$2}
             END { printf "%s:%s:%s:%s\n", nsCR, nsAR, isCR, isAR;  } ' vName=$vName )
-    set_hana_attribute ${NODENAME} "$hanarole" "${ATTR_NAME_HANA_ROLES[@]}"
+    if $setRole; then
+        set_hana_attribute ${NODENAME} "$hanarole" "${ATTR_NAME_HANA_ROLES[@]}"
+    fi
 
     # TODO PRIO2: COULD/SHOULD WE LIMIT THE SET OF THE LSS/SRR ATTRIBUTE TO ONLY THE_MASTER nodes?
     # ignore timeout (124) and "ignore" (5) as return code from the landscapeHostConfiguration call


### PR DESCRIPTION
change function saphana_demote_clone - it the role is '*:shtdown:shtdown:shtdown' let the function fail with rc=1, to get the resource stopped
change function sht_stop_clone - call landscapeHostConfiguration.py and set the roles as they are reported. If the command timed out, return 1 to get the node fenced.
the timeout for the landscapeHostConfiguration-py call is configurable by using 50% of the action timeout of the cluster
adapt the files needed for packaging

May need some discussion regarding the changed return values. Not sure, if we want to change this for scaleOut too.